### PR TITLE
Added setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+# setuptools is a more powerful version of distutils
+try:
+    from setuptools import setup
+except:
+    from distutils.core import setup
+
+setup(name='gdoc_perm_checker',
+      version='0.1',
+      description="Google drive permissions checker",
+      author="Mark Krenz",
+      url="https://github.com/deltaray/gdoc_perm_checker",
+      install_requires=[
+          "apiclient",
+          "ConfigParser",
+          "httplib2",
+          "oauth2client",
+          "urllib3"
+      ],
+      scripts=[
+          'listFiles.py',
+          'permissionList.py'
+      ]
+      )


### PR DESCRIPTION
Allows installation using './setup.py install' or './setup.py develop' (the latter installs with symlinks so you can edit scripts in place). setup.py handles dependancies.
